### PR TITLE
Fixed prototype pollution in safe-object

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ safeObject2.prototype.getter = function(prop, def = "") {
 };
 
 safeObject2.prototype.setter = function(paths, value) {
+    if (paths.includes('__proto__') || paths.includes('constructor') || paths.includes('prototype')) {
+        return false;
+    }
+
     if (paths == null || !paths) return this.objs;
     let curValue,
         idx = 0;


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-safe-object2

### ⚙️ Description *

safe-object2 is a Secure operation object get/set, this package is vulnerable to Prototype Pollution via. the setter function.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
const safeObj2 = require("safe-object2");
const obj = safeObj2({});
obj.setter(['__proto__', 'polluted'], true)
console.log(polluted);
```

![image](https://user-images.githubusercontent.com/16708391/92942673-66b66c80-f46f-11ea-9037-13c6964469d5.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/92942795-8e0d3980-f46f-11ea-8c23-8edc9e18a2cc.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `paths` and no breaking changes are introduced. :)
